### PR TITLE
Fixed CPANTESTER fail report by making Text::CSV v1.91 min requirement.

### DIFF
--- a/lib/Lingua/RU/Declension.pm
+++ b/lib/Lingua/RU/Declension.pm
@@ -5,7 +5,7 @@ use warnings;
 
 package Lingua::RU::Declension;
 
-use Text::CSV qw(csv);
+use Text::CSV 1.91 qw(csv);
 use File::Share qw(dist_file);
 use Carp qw(confess);
 


### PR DESCRIPTION
Hi @mrallen1 

Please review the PR.
Proposed to fix the following fail report.
https://www.cpantesters.org/cpan/report/6cc0dab8-529e-11e8-9da6-f703c768dc7a

Many Thanks.
Best Regards,
Mohammad S Anwar